### PR TITLE
WIP - 274 file download name should be more appropriate

### DIFF
--- a/open_budget_data_api/main.py
+++ b/open_budget_data_api/main.py
@@ -33,7 +33,12 @@ def query():
 @app.route('/api/download') # noqa
 def download():
     format = request.values.get('format', 'csv')
+
     file_name = request.values.get('filename')
+    # Create a default value here in case this parameter is not provided
+    if file_name is None:
+        file_name = 'budgetkey'
+
     formatters = request.values.get('headers').split(';')
 
     results = query_db_streaming(request.values.get('query'), formatters)


### PR DESCRIPTION
This pull request fixes #274 .

* [ ] I've added tests to cover the proposed changes

Changes proposed in this pull request:
- Instead of giving the downloaded file always the same name, the name should be taken from the parameter send in the query string.

Dependent on https://github.com/OpenBudget/budgetkey-app-generic-item/pull/107
